### PR TITLE
search page

### DIFF
--- a/src/components/search/Results.jsx
+++ b/src/components/search/Results.jsx
@@ -1,21 +1,36 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import uniqid from 'uniqid';
+import { Link } from 'gatsby';
 import { useTranslation } from 'react-i18next';
+import uniqid from 'uniqid';
 
 import useDirectorsNamespaces from '../../utils/useDirectorsNamespaces';
 
 const Searchbox = ({ filter }) => {
   const namespaces = useDirectorsNamespaces();
-  const { t } = useTranslation(namespaces);
-  const results = namespaces.map((item) => t(`${item}:name`));
+  const { t } = useTranslation(namespaces, { useSuspense: false });
+  const results = {};
+
+  namespaces.forEach((namespace, index) => {
+    const director = {
+      [t(`${namespace}:name`)]: namespaces[index],
+    };
+
+    Object.assign(results, director);
+  });
 
   return (
     <ul>
-      {results
-        .filter((item) => item.toLowerCase().includes(filter.toLowerCase()))
-        .map((item) => (
-          <li key={uniqid()}>{item}</li>
+      {Object.keys(results)
+        .filter((director) =>
+          director.toLowerCase().includes(filter.toLowerCase())
+        )
+        .map((director) => (
+          <li key={uniqid()}>
+            <Link to="/director/" state={{ director: results[director] }}>
+              {director}
+            </Link>
+          </li>
         ))}
     </ul>
   );

--- a/src/components/search/Results.jsx
+++ b/src/components/search/Results.jsx
@@ -13,7 +13,7 @@ const Searchbox = ({ filter }) => {
   return (
     <ul>
       {results
-        .filter((item) => item.includes(filter))
+        .filter((item) => item.toLowerCase().includes(filter.toLowerCase()))
         .map((item) => (
           <li key={uniqid()}>{item}</li>
         ))}

--- a/src/components/search/Results.jsx
+++ b/src/components/search/Results.jsx
@@ -6,17 +6,17 @@ import uniqid from 'uniqid';
 
 import useDirectorsNamespaces from '../../utils/useDirectorsNamespaces';
 
-const Searchbox = ({ filter }) => {
+const Result = ({ filter }) => {
   const namespaces = useDirectorsNamespaces();
-  const { t } = useTranslation(namespaces, { useSuspense: false });
+  const { t } = useTranslation(namespaces);
   const results = {};
 
-  namespaces.forEach((namespace, index) => {
-    const director = {
-      [t(`${namespace}:name`)]: namespaces[index],
+  namespaces.forEach((director, index) => {
+    const prop = {
+      [t(`${director}:name`)]: namespaces[index],
     };
 
-    Object.assign(results, director);
+    Object.assign(results, prop);
   });
 
   return (
@@ -36,8 +36,8 @@ const Searchbox = ({ filter }) => {
   );
 };
 
-Searchbox.propTypes = {
+Result.propTypes = {
   filter: PropTypes.string.isRequired,
 };
 
-export default Searchbox;
+export default Result;

--- a/src/components/search/Results.jsx
+++ b/src/components/search/Results.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import uniqid from 'uniqid';
+import { useTranslation } from 'react-i18next';
+
+import useDirectorsNamespaces from '../../utils/useDirectorsNamespaces';
+
+const Searchbox = ({ filter }) => {
+  const namespaces = useDirectorsNamespaces();
+  const { t } = useTranslation(namespaces);
+  const results = namespaces.map((item) => t(`${item}:name`));
+
+  return (
+    <ul>
+      {results
+        .filter((item) => item.includes(filter))
+        .map((item) => (
+          <li key={uniqid()}>{item}</li>
+        ))}
+    </ul>
+  );
+};
+
+Searchbox.propTypes = {
+  filter: PropTypes.string.isRequired,
+};
+
+export default Searchbox;

--- a/src/components/search/Searchbox.jsx
+++ b/src/components/search/Searchbox.jsx
@@ -1,0 +1,23 @@
+import React, { useEffect, useRef } from 'react';
+import PropTypes from 'prop-types';
+
+const Searchbox = ({ value, onChange }) => {
+  const input = useRef(null);
+
+  const handleChange = (event) => onChange(event.target.value);
+
+  useEffect(() => {
+    input.current.focus();
+  });
+
+  return (
+    <input type="text" value={value} onChange={handleChange} ref={input} />
+  );
+};
+
+Searchbox.propTypes = {
+  value: PropTypes.string.isRequired,
+  onChange: PropTypes.func.isRequired,
+};
+
+export default Searchbox;

--- a/src/pages/search.jsx
+++ b/src/pages/search.jsx
@@ -1,12 +1,20 @@
-import React, { Suspense } from 'react';
+import React, { Suspense, useState } from 'react';
 
 import Header from '../components/layout/Header';
+import Searchbox from '../components/search/Searchbox';
+import Results from '../components/search/Results';
 
-const Search = () => (
-  <>
-    <Header />
-  </>
-);
+const Search = () => {
+  const [query, setQuery] = useState('');
+
+  return (
+    <>
+      <Header />
+      <Searchbox value={query} onChange={setQuery} />
+      <Results filter={query} />
+    </>
+  );
+};
 
 const SearchWrapper = () => (
   <Suspense fallback="loading">

--- a/src/utils/useDirectorsNamespaces.jsx
+++ b/src/utils/useDirectorsNamespaces.jsx
@@ -1,0 +1,23 @@
+import { useStaticQuery, graphql } from 'gatsby';
+
+const useDirectorsNamespaces = () => {
+  const {
+    allEnJson: { edges },
+  } = useStaticQuery(
+    graphql`
+      query Namespaces {
+        allEnJson(filter: { lng: { ne: null } }) {
+          edges {
+            node {
+              path
+            }
+          }
+        }
+      }
+    `
+  );
+
+  return edges.map((item) => item.node.path.slice(1));
+};
+
+export default useDirectorsNamespaces;


### PR DESCRIPTION
Хук useDirectorsNamespaces вытягивает неймспейсы (то, что используется в t(namespace)) всех режиссёров из locales.
В компоненте Results собирается объект вида
```
{
 "director": "namespace",
 "Шмаков Фёдор Иванович": "shmakov",
  ...
}
```
И в зависимоти от текущего filter рендерятся ссылки на pages/director с нужным namespace.